### PR TITLE
libsodium: Switch source to GitHub

### DIFF
--- a/org.flathub.flatpak-external-data-checker.yml
+++ b/org.flathub.flatpak-external-data-checker.yml
@@ -214,12 +214,16 @@ modules:
           - name: libsodium
             sources:
               - type: archive
-                url: https://download.libsodium.org/libsodium/releases/libsodium-1.0.18.tar.gz
+                url: https://github.com/jedisct1/libsodium/releases/download/1.0.18-RELEASE/libsodium-1.0.18.tar.gz
                 sha256: 6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5452b46be121e46636c1
                 x-checker-data:
-                  type: html
-                  url: https://download.libsodium.org/libsodium/releases/
-                  pattern: (libsodium-([\d\.]+).tar.gz)
+                  type: json
+                  url: https://api.github.com/repos/jedisct1/libsodium/releases/latest
+                  tag-query: .tag_name
+                  version-query: $tag | sub("-RELEASE$"; "")
+                  url-query: >-
+                    .assets | map(select(.name=="libsodium-\($version).tar.gz")) |
+                    first | .browser_download_url
 
           - name: python3-cffi
             buildsystem: simple


### PR DESCRIPTION
Change the tarball source to the official repository on GitHub, as the builder failing to download
over https from libsodium.org as reported in flathub/flathub#2008, and can be seen in the build log
https://flathub.org/builds/#/builders/27/builds/61469.

~~I kept the f-e-d-c checker type property set as HTML, but using `version-pattern` with multiple releases page is an undocumented feature of the HTML checker, so maybe it's better to switch to the Anitya checker.~~