### PR TITLE
Add home directory access

### DIFF
--- a/org.flathub.flatpak-external-data-checker.yml
+++ b/org.flathub.flatpak-external-data-checker.yml
@@ -6,7 +6,7 @@ sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable
 finish-args:
   - --share=network
-  - --filesystem=host:ro
+  - --filesystem=home
 command: flatpak-external-data-checker
 cleanup:
   - '*.a'


### PR DESCRIPTION
Fixes https://github.com/flathub/org.flathub.flatpak-external-data-checker/issues/117

The only difference between home and host is it includes /etc, /usr at /run/host and exposes /run/media. I doubt anyone will try to update manifests in /etc or /usr or /media