### PR TITLE
Make PERL5LIB version independent

### DIFF
--- a/org.flathub.flatpak-external-data-checker.yml
+++ b/org.flathub.flatpak-external-data-checker.yml
@@ -264,8 +264,8 @@ modules:
         build-commands: *py3-build-commands
         sources:
           - type: archive
-            url: https://files.pythonhosted.org/packages/80/61/d3dc048cd6c7be6fe45b80cedcbdd4326ba4d550375f266d9f4246d0f4bc/lxml-5.3.2.tar.gz
-            sha256: 773947d0ed809ddad824b7b14467e1a481b8976e87278ac4a730c2f7c7fcddc1
+            url: https://files.pythonhosted.org/packages/76/3d/14e82fc7c8fb1b7761f7e748fd47e2ec8276d137b6acfe5a4bb73853e08f/lxml-5.4.0.tar.gz
+            sha256: d12832e1dbea4be280b22fd0ea7c9b87f0d8fc51ba06e92dc62d52f804f78ebd
             x-checker-data:
               type: pypi
               name: lxml

--- a/org.flathub.flatpak-external-data-checker.yml
+++ b/org.flathub.flatpak-external-data-checker.yml
@@ -17,7 +17,7 @@ cleanup:
   - /share/doc
 build-options:
   env:
-    PERL5LIB: /app/lib/perl5/vendor_perl/5.40.1
+    PERL5LIB: /app/lib/perl5
 modules:
   - name: python3-setuptools
     buildsystem: simple
@@ -122,6 +122,8 @@ modules:
               - name: dpkg
                 build-options:
                   ldflags: -ltinfo
+                  env:
+                    PERL_LIBDIR: /app/lib/perl5
                 config-opts:
                   - --sbindir=/app/bin
                   - --localstatedir=/var


### PR DESCRIPTION
This will make future runtime updates easier