### PR TITLE
Update libmd and flatpak-external-data-checker modules

### DIFF
--- a/org.flathub.flatpak-external-data-checker.yml
+++ b/org.flathub.flatpak-external-data-checker.yml
@@ -41,7 +41,7 @@ modules:
       - type: git
         url: https://github.com/flathub-infra/flatpak-external-data-checker.git
         branch: master
-        commit: 23bc928fd26573c027897bc228aa5bffe0e8542f
+        commit: 028eba8281802eaac2e0a5a70fc90b1280663578
     modules:
 
       - name: python-apt
@@ -144,8 +144,8 @@ modules:
                   - name: libmd
                     sources:
                       - type: archive
-                        url: https://archive.hadrons.org/software/libmd/libmd-1.0.4.tar.xz
-                        sha256: f51c921042e34beddeded4b75557656559cf5b1f2448033b4c1eec11c07e530f
+                        url: https://libbsd.freedesktop.org/releases/libmd-1.1.0.tar.xz
+                        sha256: 1bd6aa42275313af3141c7cf2e5b964e8b1fd488025caf2f971f43b00776b332
                         x-checker-data:
                           type: anitya
                           project-id: 15525

--- a/org.flathub.flatpak-external-data-checker.yml
+++ b/org.flathub.flatpak-external-data-checker.yml
@@ -161,15 +161,6 @@ modules:
                     url: https://github.com/julian-klode/triehash/archive/v0.3.tar.gz
                     sha256: 289a0966c02c2008cd263d3913a8e3c84c97b8ded3e08373d63a382c71d2199c
 
-              - name: xxhash
-                no-autogen: true
-                make-install-args:
-                  - PREFIX=$(FLATPAK_DEST)
-                sources:
-                  - type: archive
-                    url: https://github.com/Cyan4973/xxHash/archive/v0.8.0.tar.gz
-                    sha256: 7054c3ebd169c97b64a92d7b994ab63c70dd53a06974f1f630ab782c28db0f4f
-
       - name: pygobject
         buildsystem: meson
         sources:


### PR DESCRIPTION
libmd: Update libmd-1.0.4.tar.xz to 1.1.0
flatpak-external-data-checker: Update flatpak-external-data-checker.git